### PR TITLE
chore: set stable channel as default when using fvm config

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -12,4 +12,10 @@ cache_file="$(cache_dir)/list-all-versions.txt"
 create_cache_file "$cache_file" "$((60 * 60 * 24))"
 
 version="$(parse_fvm_config "$1")"
+
+# Check if version contains stable/dev/beta, if not, set channel to stable
+if [[ ! "$version" == *stable && ! "$version" == *dev && ! "$version" == *beta ]]; then
+    version="${version}-stable"
+fi
+
 grep <"$cache_file" "$version" | tail -n1 | xargs echo


### PR DESCRIPTION
Hi, thank you for creating this!
I made the default channel set "stable" when using the fvm config because the plugin selected the unexpected latest release.

For instance;
Flutter SDK version "3.22.0" has below versions:
```
3.22.0-stable
3.22.0-0.1.pre-beta
3.22.0-0.2.pre-beta
3.22.0-0.3.pre-beta
```

If the .fvmrc was this:
```
{
  "flutter": "3.22.0"
}
```

It will attemp to get "3.22.0-0.3.pre-beta"