### PR TITLE
feat: Support `ref` and fork installs

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -24,6 +24,7 @@ if [ "$ASDF_INSTALL_TYPE" = "version" ]; then
 	rm "$release_file"
 
 elif [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
+	# A commit/tag/branch can be specified using the "ref:<some-ref>" syntax
 
 	git clone --filter=blob:none --no-checkout "$ASDF_FLUTTER_SOURCE_REPO_URL" "$ASDF_DOWNLOAD_PATH"
 
@@ -34,5 +35,5 @@ elif [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
 	git checkout "$ASDF_INSTALL_VERSION"
 
 else
-	fail "Unknown install type $ASDF_INSTALL_TYPE"
+	fail "Unknown install type: $ASDF_INSTALL_TYPE"
 fi

--- a/bin/download
+++ b/bin/download
@@ -1,22 +1,39 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+echo "INSTALL TYPE!! $ASDF_INSTALL_TYPE"
+echo "DOWNLOAD!! $ASDF_DOWNLOAD_PATH"
+echo "ASDF_INSTALL_VERSION!! $ASDF_INSTALL_VERSION"
+echo "ASDF_INSTALL_PATH!! $ASDF_INSTALL_PATH"
+
 
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
+echo "HOLA!! $plugin_dir"
 
 # shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.$(platform_extension)"
+if [ "$ASDF_INSTALL_TYPE" = "version" ]; then
 
-# Download tar.gz file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+	release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.$(platform_extension)"
 
-#  Extract contents of tar.gz file into the download directory
-$(platform_tar) -xf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+	echo "Release file: $release_file  $ASDF_DOWNLOAD_PATH"
 
-# Remove the tar.gz file since we don't need to keep it
-rm "$release_file"
+	# Download tar.gz file to the download directory
+	download_release "$ASDF_INSTALL_VERSION" "$release_file"
+
+	#  Extract contents of tar.gz file into the download directory
+	$(platform_tar) -xf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+
+	# Remove the tar.gz file since we don't need to keep it
+	rm "$release_file"
+
+elif [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
+	:
+
+else
+	fail "Unknown install type $ASDF_INSTALL_TYPE"
+fi

--- a/bin/download
+++ b/bin/download
@@ -1,15 +1,9 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-echo "INSTALL TYPE!! $ASDF_INSTALL_TYPE"
-echo "DOWNLOAD!! $ASDF_DOWNLOAD_PATH"
-echo "ASDF_INSTALL_VERSION!! $ASDF_INSTALL_VERSION"
-echo "ASDF_INSTALL_PATH!! $ASDF_INSTALL_PATH"
-
 
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
-echo "HOLA!! $plugin_dir"
 
 # shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
@@ -19,8 +13,6 @@ mkdir -p "$ASDF_DOWNLOAD_PATH"
 if [ "$ASDF_INSTALL_TYPE" = "version" ]; then
 
 	release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.$(platform_extension)"
-
-	echo "Release file: $release_file  $ASDF_DOWNLOAD_PATH"
 
 	# Download tar.gz file to the download directory
 	download_release "$ASDF_INSTALL_VERSION" "$release_file"
@@ -33,12 +25,12 @@ if [ "$ASDF_INSTALL_TYPE" = "version" ]; then
 
 elif [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
 
-	echo "Cloning $ASDF_FLUTTER_SOURCE_REPO_URL to $ASDF_DOWNLOAD_PATH"
-
 	git clone --filter=blob:none --no-checkout "$ASDF_FLUTTER_SOURCE_REPO_URL" "$ASDF_DOWNLOAD_PATH"
+
 	cd "$ASDF_DOWNLOAD_PATH"
 
 	git fetch --depth 1 origin "$ASDF_INSTALL_VERSION"
+
 	git checkout "$ASDF_INSTALL_VERSION"
 
 else

--- a/bin/download
+++ b/bin/download
@@ -32,7 +32,14 @@ if [ "$ASDF_INSTALL_TYPE" = "version" ]; then
 	rm "$release_file"
 
 elif [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
-	:
+
+	echo "Cloning $ASDF_FLUTTER_SOURCE_REPO_URL to $ASDF_DOWNLOAD_PATH"
+
+	git clone --filter=blob:none --no-checkout "$ASDF_FLUTTER_SOURCE_REPO_URL" "$ASDF_DOWNLOAD_PATH"
+	cd "$ASDF_DOWNLOAD_PATH"
+
+	git fetch --depth 1 origin "$ASDF_INSTALL_VERSION"
+	git checkout "$ASDF_INSTALL_VERSION"
 
 else
 	fail "Unknown install type $ASDF_INSTALL_TYPE"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-echo "INPUT URL ${ASDF_FLUTTER_SOURCE_REPO_URL:-fallback}"
-
 # An user of the plugin could specify a custom Flutter fork
+# using Mise environment variables for example: https://mise.jdx.dev/environments/
 export ASDF_FLUTTER_SOURCE_REPO_URL=${ASDF_FLUTTER_SOURCE_REPO_URL:-"https://github.com/flutter/flutter"}
 
 FLUTTER_LIST_BASE_URL="https://storage.googleapis.com"
@@ -199,19 +198,14 @@ install_version() {
 	local install_path="${3%/bin}"
 	local bin_path="$install_path/bin"
 
-	echo "Install type: $install_type"
-	echo "Version: $version"
-	echo "Install path: $install_path"
-	echo "Bin path: $bin_path"
-
 	if [ "$install_type" != "version" ] && [ "$install_type" != "ref" ]; then
 		fail "asdf-$TOOL_NAME supports release and ref installs only"
 	fi
 
-	rmdir "$install_path"
-	mv "$ASDF_DOWNLOAD_PATH" "$install_path"
-
 	(
+		rmdir "$install_path"
+		mv "$ASDF_DOWNLOAD_PATH" "$install_path"
+
 		local tool_cmd
 		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
 		test -x "$bin_path/$tool_cmd" || fail "Expected $bin_path/$tool_cmd to be executable."

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+echo "INPUT URL ${ASDF_FLUTTER_SOURCE_REPO_URL:-fallback}"
+
+# An user of the plugin could specify a custom Flutter fork
+export ASDF_FLUTTER_SOURCE_REPO_URL=${ASDF_FLUTTER_SOURCE_REPO_URL:-"https://github.com/flutter/flutter"}
+
 FLUTTER_LIST_BASE_URL="https://storage.googleapis.com"
 JQ_DOWNLOAD_BASE_URL="https://github.com/jqlang/jq/releases/latest/download"
 TOOL_NAME="flutter"
@@ -203,15 +208,8 @@ install_version() {
 		fail "asdf-$TOOL_NAME supports release and ref installs only"
 	fi
 
-	if [ "$install_type" = "ref" ]; then
-		git clone --depth 1 https://github.com/flutter/flutter "$install_path"
-		cd "$install_path"
-		git fetch --depth=1 origin "$version"
-		git checkout "$version"
-	elif [ "$install_type" = "version" ]; then
-		rmdir "$install_path"
-		mv "$ASDF_DOWNLOAD_PATH" "$install_path"
-	fi
+	rmdir "$install_path"
+	mv "$ASDF_DOWNLOAD_PATH" "$install_path"
 
 	(
 		local tool_cmd

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -194,14 +194,26 @@ install_version() {
 	local install_path="${3%/bin}"
 	local bin_path="$install_path/bin"
 
-	if [ "$install_type" != "version" ]; then
-		fail "asdf-$TOOL_NAME supports release installs only"
+	echo "Install type: $install_type"
+	echo "Version: $version"
+	echo "Install path: $install_path"
+	echo "Bin path: $bin_path"
+
+	if [ "$install_type" != "version" ] && [ "$install_type" != "ref" ]; then
+		fail "asdf-$TOOL_NAME supports release and ref installs only"
+	fi
+
+	if [ "$install_type" = "ref" ]; then
+		git clone --depth 1 https://github.com/flutter/flutter "$install_path"
+		cd "$install_path"
+		git fetch --depth=1 origin "$version"
+		git checkout "$version"
+	elif [ "$install_type" = "version" ]; then
+		rmdir "$install_path"
+		mv "$ASDF_DOWNLOAD_PATH" "$install_path"
 	fi
 
 	(
-		rmdir "$install_path"
-		mv "$ASDF_DOWNLOAD_PATH" "$install_path"
-
 		local tool_cmd
 		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
 		test -x "$bin_path/$tool_cmd" || fail "Expected $bin_path/$tool_cmd to be executable."


### PR DESCRIPTION
This PR adds the option to install a version from a git reference. That can be a commit hash, a tag or a branch name. The ref install_type is supported by asdf.

Additionally, I added the option to clone/fetch from a different Flutter repository as an environment variable. This is useful to configure a version comming from a Flutter fork.

Using mise, this would be an example:

```toml
[env]
ASDF_FLUTTER_SOURCE_REPO_URL = "https://github.com/<some-user>/flutter"

[tools]
flutter = "ref:mytag"
flutter = "ref:ac9f68b12da80cd79c60074556f2fa286419af86"
```