### PR TITLE
fix: `--keep-download` option of `install` subcommand is ignored

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -221,7 +221,7 @@ install_version() {
 
 	(
 		rmdir "$install_path"
-		mv "$ASDF_DOWNLOAD_PATH" "$install_path"
+		cp -ipR "$ASDF_DOWNLOAD_PATH" "$install_path"
 
 		local tool_cmd
 		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"


### PR DESCRIPTION
Use `cp` instead of `mv`.